### PR TITLE
Fix addEmojiToRecentlyUsed

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,14 @@ EmojiPicker(
 
 ```
 // Get recently used emoji
-final recentEmojis = await EmojiPickerUtils.getRecentEmojis();
+final recentEmojis = await EmojiPickerUtils().getRecentEmojis();
 
 // Search for related emoticons based on keywords
-final filterEmojiEntities = await EmojiPickerUtils.searchEmoji("face");
+final filterEmojiEntities = await EmojiPickerUtils().searchEmoji("face");
 
 // Add an emoji to recently used list or increase its counter
-final newRecentEmojis = await EmojiPickerUtils.addEmojiToRecentlyUsed(emoji: emoji);
+final newRecentEmojis = await EmojiPickerUtils().addEmojiToRecentlyUsed(key: key, emoji: emoji);
+// Important: Needs same key instance of type GlobalKey<EmojiPickerState> here and for the EmojiPicker-Widget in order to work properly
 ```
 
 ## Feel free to contribute to this package!! 🙇‍♂️

--- a/lib/src/emoji_picker_internal_utils.dart
+++ b/lib/src/emoji_picker_internal_utils.dart
@@ -1,10 +1,12 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 
 import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
 import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'emoji_lists.dart' as $emoji_list;
+import 'recent_emoji.dart';
 
 /// Helper class that provides internal usage
 class EmojiPickerInternalUtils {
@@ -103,5 +105,41 @@ class EmojiPickerInternalUtils {
     } else {
       return emoji;
     }
+  }
+
+  /// Returns list of recently used emoji from cache
+  Future<List<RecentEmoji>> getRecentEmojis() async {
+    final prefs = await SharedPreferences.getInstance();
+    var emojiJson = prefs.getString('recent');
+    if (emojiJson == null) {
+      return [];
+    }
+    var json = jsonDecode(emojiJson) as List<dynamic>;
+    return json.map<RecentEmoji>(RecentEmoji.fromJson).toList();
+  }
+
+  /// Add an emoji to recently used list or increase its counter
+  Future<List<RecentEmoji>> addEmojiToRecentlyUsed(
+      {required Emoji emoji, Config config = const Config()}) async {
+    final prefs = await SharedPreferences.getInstance();
+    var recentEmoji = await getRecentEmojis();
+    var recentEmojiIndex =
+        recentEmoji.indexWhere((element) => element.emoji.emoji == emoji.emoji);
+    if (recentEmojiIndex != -1) {
+      // Already exist in recent list
+      // Just update counter
+      recentEmoji[recentEmojiIndex].counter++;
+    } else {
+      recentEmoji.add(RecentEmoji(emoji, 1));
+    }
+    // Sort by counter desc
+    recentEmoji.sort((a, b) => b.counter - a.counter);
+    // Limit entries to recentsLimit
+    recentEmoji =
+        recentEmoji.sublist(0, min(config.recentsLimit, recentEmoji.length));
+    // save locally
+    prefs.setString('recent', jsonEncode(recentEmoji));
+
+    return recentEmoji;
   }
 }

--- a/lib/src/emoji_picker_utils.dart
+++ b/lib/src/emoji_picker_utils.dart
@@ -1,28 +1,27 @@
-import 'dart:convert';
-import 'dart:math';
-
 import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
 import 'package:emoji_picker_flutter/src/recent_emoji.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter/material.dart';
 import 'emoji_picker_internal_utils.dart';
 
 /// Helper class that provides extended usage
 class EmojiPickerUtils {
-  static final List<Emoji> _allAvailableEmojiEntities = [];
+  /// Singleton Constructor
+  factory EmojiPickerUtils() {
+    return _singleton;
+  }
+
+  EmojiPickerUtils._internal();
+
+  static final EmojiPickerUtils _singleton = EmojiPickerUtils._internal();
+  final List<Emoji> _allAvailableEmojiEntities = [];
 
   /// Returns list of recently used emoji from cache
-  static Future<List<RecentEmoji>> getRecentEmojis() async {
-    final prefs = await SharedPreferences.getInstance();
-    var emojiJson = prefs.getString('recent');
-    if (emojiJson == null) {
-      return [];
-    }
-    var json = jsonDecode(emojiJson) as List<dynamic>;
-    return json.map<RecentEmoji>(RecentEmoji.fromJson).toList();
+  Future<List<RecentEmoji>> getRecentEmojis() async {
+    return EmojiPickerInternalUtils().getRecentEmojis();
   }
 
   /// Search for related emoticons based on keywords
-  static Future<List<Emoji>> searchEmoji(String keyword) async {
+  Future<List<Emoji>> searchEmoji(String keyword) async {
     if (keyword.isEmpty) return [];
 
     if (_allAvailableEmojiEntities.isEmpty) {
@@ -45,27 +44,14 @@ class EmojiPickerUtils {
   }
 
   /// Add an emoji to recently used list or increase its counter
-  static Future<List<RecentEmoji>> addEmojiToRecentlyUsed(
-      {required Emoji emoji, Config config = const Config()}) async {
-    final prefs = await SharedPreferences.getInstance();
-    var recentEmoji = await getRecentEmojis();
-    var recentEmojiIndex =
-        recentEmoji.indexWhere((element) => element.emoji.emoji == emoji.emoji);
-    if (recentEmojiIndex != -1) {
-      // Already exist in recent list
-      // Just update counter
-      recentEmoji[recentEmojiIndex].counter++;
-    } else {
-      recentEmoji.add(RecentEmoji(emoji, 1));
-    }
-    // Sort by counter desc
-    recentEmoji.sort((a, b) => b.counter - a.counter);
-    // Limit entries to recentsLimit
-    recentEmoji =
-        recentEmoji.sublist(0, min(config.recentsLimit, recentEmoji.length));
-    // save locally
-    prefs.setString('recent', jsonEncode(recentEmoji));
-
-    return recentEmoji;
+  Future addEmojiToRecentlyUsed({
+    required GlobalKey<EmojiPickerState> key,
+    required Emoji emoji,
+    Config config = const Config(),
+  }) async {
+    return EmojiPickerInternalUtils()
+        .addEmojiToRecentlyUsed(emoji: emoji, config: config)
+        .then((recentEmojiList) =>
+            key.currentState?.updateRecentEmoji(recentEmojiList));
   }
 }

--- a/lib/src/emoji_picker_utils.dart
+++ b/lib/src/emoji_picker_utils.dart
@@ -39,7 +39,9 @@ class EmojiPickerUtils {
     }
 
     return _allAvailableEmojiEntities
-        .where((emoji) => emoji.name.contains(keyword))
+        .where(
+          (emoji) => emoji.name.toLowerCase().contains(keyword.toLowerCase()),
+        )
         .toList();
   }
 


### PR DESCRIPTION
- Make `EmojiPickerState` public, in order to be able to rebuild the widget from outside
- Changed `EmojiPickerUtils` from `static` to `singleton instance` to save memory
- Move `addEmojiToRecentlyUsed` and `getRecentEmojis` to `EmojiPickerInternalUtils` and just provide access from `EmojiPickerUtils`